### PR TITLE
Fix #3: Blank activity when clicking on notification

### DIFF
--- a/src/android/PushyMeHandlerActivity.java
+++ b/src/android/PushyMeHandlerActivity.java
@@ -23,6 +23,7 @@ public class PushyMeHandlerActivity extends Activity
 	{
 		super.onCreate(savedInstanceState);
 		Log.v(TAG, "onCreate");
+		forceMainActivityReload();
     }
   /**
 	 * Forces the main activity to re-launch if it's unloaded.
@@ -30,8 +31,10 @@ public class PushyMeHandlerActivity extends Activity
 	private void forceMainActivityReload()
 	{
 		PackageManager pm = getPackageManager();
-		Intent launchIntent = pm.getLaunchIntentForPackage(getApplicationContext().getPackageName());    		
+		Intent launchIntent = pm.getLaunchIntentForPackage(getApplicationContext().getPackageName());    
+		launchIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);		
 		startActivity(launchIntent);
+		finish();
 	}
 
   @Override


### PR DESCRIPTION
Hi @LokeshPatel,
Thanks so much for your work on this project!

This PR fixes issue #3:

1) Modified [PushyMeHandlerActivity.java](https://github.com/LokeshPatel/Cordova-Plugin-CDVPushyMe/blob/e38cc799f0372bf51a24d34fea001beffef6a08d/src/android/PushyMeHandlerActivity.java) to call `forceMainActivityReload()` within the `onCreate()`
2) Modified `forceMainActivityReload()` to call `finish()` after starting the main activity
3) Modified `forceMainActivityReload()`'s `launchIntent` flags to `Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP` so that the main activity won't open more than once